### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "python3"
+run = "python JoCryptL.py"

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Encryption Program.
 
+[![Run on Repl.it](https://repl.it/badge/github/SidJo15/JoCrypt)](https://repl.it/github/SidJo15/JoCrypt)
+
 # Executable
 
 You can download the executable for any Windows System from the following link:


### PR DESCRIPTION
This pull request configures this repository to be run on Repl.it.      It adds a `.replit` configuration file and a Repl.it badge to the `README`.
     You can read more about running repos on Repl.it [here](https://docs.repl.it/repls/dot-replit), or view the Repl [here](https://repl.it/@SidJo/JoCrypt).